### PR TITLE
Fix broken user settings storage on non-Windows systems

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ skip_tags: true
 image: Visual Studio 2017
 build_script:
 - pwsh: '& ".\build.ps1"'
-test: off
 deploy_script:
 - pwsh: Publish-Module -NuGetApiKey $env:psgallery -Path .\publish\JournalCli
 environment:

--- a/src/JournalCli.Tests/JournalCli.Tests.csproj
+++ b/src/JournalCli.Tests/JournalCli.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="FakeItEasy" Version="5.1.1" />
     <PackageReference Include="FluentAssertions" Version="5.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/src/JournalCli.Tests/JournalCli.Tests.csproj
+++ b/src/JournalCli.Tests/JournalCli.Tests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="6.0.21" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="6.0.21" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/src/JournalCli.Tests/JournalCli.Tests.csproj
+++ b/src/JournalCli.Tests/JournalCli.Tests.csproj
@@ -7,11 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="6.0.21" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="6.0.21" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="FakeItEasy" Version="5.1.1" />
+    <PackageReference Include="FluentAssertions" Version="5.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="6.0.23" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="6.0.23" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/JournalCli.Tests/MacEncryptedStoreTests.cs
+++ b/src/JournalCli.Tests/MacEncryptedStoreTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using AutoFixture;
+using FakeItEasy;
+using FluentAssertions;
+using Xunit;
+
+namespace JournalCli.Tests
+{
+    public class MacEncryptedStoreTests
+    {
+        readonly Fixture _fixture = new Fixture();
+
+        [Fact]
+        public void Constructor_CreatesKeys_IfNotExists()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            var dataDirectory = fileSystem.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JournalCli");
+            fileSystem.AllDirectories.Should().NotContain(dataDirectory);
+
+            var store = new MacEncryptedStore<UserSettings>(fileSystem);
+            fileSystem.AllDirectories.Should().Contain(dataDirectory);
+            fileSystem.Directory.GetFiles(dataDirectory).Length.Should().Be(2, "There should be an encryption key and an auth key present.");
+        }
+
+        [Fact]
+        public void Save_WritesCipherToDisk()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            var dataDirectory = fileSystem.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JournalCli");
+
+            var savingStore = new MacEncryptedStore<UserSettings>(fileSystem);
+            fileSystem.Directory.GetFiles(dataDirectory).Length.Should().Be(2);
+            var settings = _fixture.Create<UserSettings>();
+            savingStore.Save(settings);
+
+            fileSystem.Directory.GetFiles(dataDirectory).Length.Should().Be(3);
+        }
+
+        [Fact]
+        public void Load_CorrectlyRestoresSavedValue()
+        {
+            var fileSystem = new MockFileSystem();
+            var store = new MacEncryptedStore<UserSettings>(fileSystem);
+            var settings = _fixture.Create<UserSettings>();
+            store.Save(settings);
+
+            var result = store.Load();
+            result.Should().BeEquivalentTo(settings);
+        }
+
+        [Fact]
+        public void Load_ReturnsEmptyObject_WhenNoSavedObjectExists()
+        {
+            var fileSystem = new MockFileSystem();
+            var store = new MacEncryptedStore<UserSettings>(fileSystem);
+
+            var result = store.Load();
+            result.Should().BeEquivalentTo(new UserSettings());
+        }
+    }
+}

--- a/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
+++ b/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using AutoFixture;
 using FakeItEasy;
 using FluentAssertions;
 using Xunit;
@@ -9,6 +10,8 @@ namespace JournalCli.Tests
 {
     public class WindowsEncryptedStoreTests
     {
+        private readonly Fixture _fixture = new Fixture();
+
         [Fact]
         public void Save_WritesCipherAndEntropyToDisk()
         {
@@ -25,12 +28,7 @@ namespace JournalCli.Tests
         {
             var fileSystem = new MockFileSystem();
             var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
-            var settings = new UserSettings
-            {
-                BackupPassword = "secret",
-                BackupLocation = "C:\\MyJournalBackup",
-                DefaultJournalRoot = "D:\\MyJournal"
-            };
+            var settings = _fixture.Create<UserSettings>();
             store.Save(settings);
 
             var result = store.Load();
@@ -47,12 +45,7 @@ namespace JournalCli.Tests
             fileSystem.AllDirectories.Should().NotContain(dataDirectory);
 
             var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
-            var settings = new UserSettings
-            {
-                BackupPassword = "secret",
-                BackupLocation = "C:\\MyJournalBackup",
-                DefaultJournalRoot = "D:\\MyJournal"
-            };
+            var settings = _fixture.Create<UserSettings>();
             store.Save(settings);
 
             fileSystem.AllDirectories.Should().Contain(dataDirectory);

--- a/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
+++ b/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
@@ -1,4 +1,8 @@
 using System;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using FakeItEasy;
+using FluentAssertions;
 using Xunit;
 
 namespace JournalCli.Tests
@@ -6,10 +10,62 @@ namespace JournalCli.Tests
     public class WindowsEncryptedStoreTests
     {
         [Fact]
-        public void Test1()
+        public void Save_WritesCipherAndEntropyToDisk()
         {
-            //var md = new MarkdownFiles();
-            //var files = md.FindAll("J:\\");
+            var fileSystem = A.Fake<IFileSystem>();
+            var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
+            var settings = new UserSettings { BackupPassword = "secret" };
+            store.Save(settings);
+
+            A.CallTo(() => fileSystem.File.WriteAllBytes(A<string>.Ignored, A<byte[]>.Ignored)).MustHaveHappenedTwiceExactly();
+        }
+
+        [Fact]
+        public void Load_CorrectlyRestoresSavedValue()
+        {
+            var fileSystem = new MockFileSystem();
+            var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
+            var settings = new UserSettings
+            {
+                BackupPassword = "secret",
+                BackupLocation = "C:\\MyJournalBackup",
+                DefaultJournalRoot = "D:\\MyJournal"
+            };
+            store.Save(settings);
+
+            var result = store.Load();
+            result.Should().BeEquivalentTo(settings);
+        }
+
+        [Fact]
+        public void WindowsEncryptedStore_CreatesDataDirectory_WhenItDoesntExist()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+            var dataDirectory = fileSystem.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "JournalCli");
+
+            fileSystem.AllDirectories.Should().NotContain(dataDirectory);
+
+            var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
+            var settings = new UserSettings
+            {
+                BackupPassword = "secret",
+                BackupLocation = "C:\\MyJournalBackup",
+                DefaultJournalRoot = "D:\\MyJournal"
+            };
+            store.Save(settings);
+
+            fileSystem.AllDirectories.Should().Contain(dataDirectory);
+        }
+
+        [Fact]
+        public void Load_ReturnsEmptyObject_WhenNoSavedObjectExists()
+        {
+            var fileSystem = new MockFileSystem();
+            var store = new WindowsEncryptedStore<UserSettings>(fileSystem);
+
+            var result = store.Load();
+            result.Should().BeEquivalentTo(new UserSettings());
         }
     }
 }

--- a/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
+++ b/src/JournalCli.Tests/WindowsEncryptedStoreTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace JournalCli.Tests
 {
-    public class UnitTest1
+    public class WindowsEncryptedStoreTests
     {
         [Fact]
         public void Test1()

--- a/src/JournalCli/AssemblyInfo.cs
+++ b/src/JournalCli/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("JournalCli.Tests")]

--- a/src/JournalCli/Commands/BackupJournalCmdlet.cs
+++ b/src/JournalCli/Commands/BackupJournalCmdlet.cs
@@ -25,7 +25,7 @@ namespace JournalCli.Commands
             base.ProcessRecord();
 
             var fileSystem = new FileSystem();
-            var encryptedStore = EncryptedStoreFactory.Create();
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
 
             if (string.IsNullOrWhiteSpace(BackupLocation))

--- a/src/JournalCli/Commands/BackupJournalCmdlet.cs
+++ b/src/JournalCli/Commands/BackupJournalCmdlet.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO.Abstractions;
 using System.Management.Automation;
 using ICSharpCode.SharpZipLib.Zip;
 using JetBrains.Annotations;
@@ -13,75 +13,49 @@ namespace JournalCli.Commands
         [Parameter]
         public string BackupLocation { get; set; }
 
+        // TODO: Collect this in a more secure way
         [Parameter]
         public string Password { get; set; }
 
         [Parameter]
-        public SwitchParameter SaveLocation { get; set; }
-
-        [Parameter]
-        public SwitchParameter SavePassword { get; set; }
+        public SwitchParameter SaveParameters { get; set; }
 
         protected override void ProcessRecord()
         {
-            ResolveBackupLocation();
-            ResolvePassword();
+            base.ProcessRecord();
+
+            var fileSystem = new FileSystem();
+            var encryptedStore = EncryptedStoreFactory.Create();
+            var settings = UserSettings.Load(encryptedStore);
+
+            if (string.IsNullOrWhiteSpace(BackupLocation))
+            {
+                if (string.IsNullOrWhiteSpace(settings.BackupLocation))
+                    throw new PSInvalidOperationException("Backup location not provided and no location was previously saved.");
+            }
+            else
+            {
+                settings.BackupLocation = ResolvePath(BackupLocation);
+            }
+
+            if (!string.IsNullOrWhiteSpace(Password))
+            {
+                settings.BackupPassword = Password;
+            }
+
+            if (SaveParameters)
+            {
+                encryptedStore.Save(settings);
+            }
+
+            if (!fileSystem.Directory.Exists(BackupLocation))
+                fileSystem.Directory.CreateDirectory(BackupLocation);
 
             var fileName = $"{DateTime.Now:yyyy.MM.dd.H.mm.ss.FFF}.zip";
-            var destinationPath = Path.Combine(BackupLocation, fileName);
-            var journalRoot = GetResolvedRootDirectory();
+            var destinationPath = fileSystem.Path.Combine(BackupLocation, fileName);
 
             var zip = new FastZip { CreateEmptyDirectories = true, Password = Password };
-            zip.CreateZip(destinationPath, journalRoot, true, null);
-        }
-
-        private void ResolveBackupLocation()
-        {
-            if (string.IsNullOrEmpty(BackupLocation))
-            {
-                var settings = UserSettings.Load();
-                if (string.IsNullOrEmpty(settings.BackupLocation))
-                    throw new PSInvalidOperationException("Backup location not provided and no location was previously saved.");
-
-                BackupLocation = settings.BackupLocation;
-            }
-            else
-            {
-                if (!Directory.Exists(BackupLocation))
-                    Directory.CreateDirectory(BackupLocation);
-
-                BackupLocation = ResolvePath(BackupLocation);
-                if (SaveLocation)
-                {
-                    var settings = UserSettings.Load();
-                    settings.BackupLocation = BackupLocation;
-                    settings.Save();
-                }
-            }
-        }
-
-        private void ResolvePassword()
-        {
-            if (string.IsNullOrEmpty(Password))
-            {
-                var settings = UserSettings.Load();
-                if (string.IsNullOrEmpty(settings.BackupPassword))
-                {
-                    Password = null;
-                    return;
-                }
-
-                Password = settings.BackupPassword;
-            }
-            else
-            {
-                if (SavePassword)
-                {
-                    var settings = UserSettings.Load();
-                    settings.BackupPassword = Password;
-                    settings.Save();
-                }
-            }
+            zip.CreateZip(destinationPath, RootDirectory, true, null);
         }
     }
 }

--- a/src/JournalCli/Commands/GetDefaultJournalLocationCmdlet.cs
+++ b/src/JournalCli/Commands/GetDefaultJournalLocationCmdlet.cs
@@ -10,7 +10,7 @@ namespace JournalCli.Commands
     {
         protected override void ProcessRecord()
         {
-            var encryptedStore = EncryptedStoreFactory.Create();
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
             WriteObject(settings.DefaultJournalRoot);
         }

--- a/src/JournalCli/Commands/GetDefaultJournalLocationCmdlet.cs
+++ b/src/JournalCli/Commands/GetDefaultJournalLocationCmdlet.cs
@@ -10,10 +10,8 @@ namespace JournalCli.Commands
     {
         protected override void ProcessRecord()
         {
-            if (!UserSettings.Exists())
-                return;
-
-            var settings = UserSettings.Load();
+            var encryptedStore = EncryptedStoreFactory.Create();
+            var settings = UserSettings.Load(encryptedStore);
             WriteObject(settings.DefaultJournalRoot);
         }
     }

--- a/src/JournalCli/Commands/GetJournalEntriesByTagCmdlet.cs
+++ b/src/JournalCli/Commands/GetJournalEntriesByTagCmdlet.cs
@@ -16,8 +16,8 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var root = GetResolvedRootDirectory();
-            var index = Journal.CreateIndex(root, IncludeHeaders);
+            base.ProcessRecord();
+            var index = Journal.CreateIndex(RootDirectory, IncludeHeaders);
 
             var result = index.Where(x => Tags.Contains(x.Tag));
             WriteObject(result, true);

--- a/src/JournalCli/Commands/GetJournalEntriesByTagCmdlet.cs
+++ b/src/JournalCli/Commands/GetJournalEntriesByTagCmdlet.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.IO.Abstractions;
+using System.Management.Automation;
 using JetBrains.Annotations;
 using System.Linq;
 
@@ -17,7 +18,9 @@ namespace JournalCli.Commands
         protected override void ProcessRecord()
         {
             base.ProcessRecord();
-            var index = Journal.CreateIndex(RootDirectory, IncludeHeaders);
+            var fileSystem = new FileSystem();
+            var journal = Journal.Open(fileSystem, RootDirectory);
+            var index = journal.CreateIndex(IncludeHeaders);
 
             var result = index.Where(x => Tags.Contains(x.Tag));
             WriteObject(result, true);

--- a/src/JournalCli/Commands/GetJournalIndexCmdlet.cs
+++ b/src/JournalCli/Commands/GetJournalIndexCmdlet.cs
@@ -22,8 +22,8 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var root = GetResolvedRootDirectory();
-            var index = Journal.CreateIndex(root, IncludeHeaders);
+            base.ProcessRecord();
+            var index = Journal.CreateIndex(RootDirectory, IncludeHeaders);
 
             switch (OrderBy)
             {

--- a/src/JournalCli/Commands/GetJournalIndexCmdlet.cs
+++ b/src/JournalCli/Commands/GetJournalIndexCmdlet.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.IO.Abstractions;
+using System.Management.Automation;
 using JetBrains.Annotations;
 using System.Linq;
 
@@ -23,7 +24,10 @@ namespace JournalCli.Commands
         protected override void ProcessRecord()
         {
             base.ProcessRecord();
-            var index = Journal.CreateIndex(RootDirectory, IncludeHeaders);
+
+            var fileSystem = new FileSystem();
+            var journal = Journal.Open(fileSystem, RootDirectory);
+            var index = journal.CreateIndex(IncludeHeaders);
 
             switch (OrderBy)
             {

--- a/src/JournalCli/Commands/JournalCmdletBase.cs
+++ b/src/JournalCli/Commands/JournalCmdletBase.cs
@@ -17,7 +17,7 @@ namespace JournalCli.Commands
                 return;
             }
 
-            var encryptedStore = EncryptedStoreFactory.Create();
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
 
             if (string.IsNullOrEmpty(settings.DefaultJournalRoot))

--- a/src/JournalCli/Commands/JournalCmdletBase.cs
+++ b/src/JournalCli/Commands/JournalCmdletBase.cs
@@ -9,19 +9,18 @@ namespace JournalCli.Commands
         [Parameter]
         public string RootDirectory { get; set; }
 
-        protected string GetResolvedRootDirectory()
+        protected override void ProcessRecord()
         {
             if (!string.IsNullOrEmpty(RootDirectory))
-                return ResolvePath(RootDirectory);
+                RootDirectory = ResolvePath(RootDirectory);
 
-            if (!UserSettings.Exists())
-                throw new PSInvalidOperationException(_error);
+            var encryptedStore = EncryptedStoreFactory.Create();
+            var settings = UserSettings.Load(encryptedStore);
 
-            var settings = UserSettings.Load();
             if (string.IsNullOrEmpty(settings.DefaultJournalRoot))
                 throw new PSInvalidOperationException(_error);
 
-            return settings.DefaultJournalRoot;
+            RootDirectory = settings.DefaultJournalRoot;
         }
     }
 }

--- a/src/JournalCli/Commands/JournalCmdletBase.cs
+++ b/src/JournalCli/Commands/JournalCmdletBase.cs
@@ -12,7 +12,10 @@ namespace JournalCli.Commands
         protected override void ProcessRecord()
         {
             if (!string.IsNullOrEmpty(RootDirectory))
+            {
                 RootDirectory = ResolvePath(RootDirectory);
+                return;
+            }
 
             var encryptedStore = EncryptedStoreFactory.Create();
             var settings = UserSettings.Load(encryptedStore);

--- a/src/JournalCli/Commands/NewJournalEntryCmdlet.cs
+++ b/src/JournalCli/Commands/NewJournalEntryCmdlet.cs
@@ -41,7 +41,7 @@ namespace JournalCli.Commands
                 fs.WriteLine("---");
                 fs.WriteLine("tags:");
 
-                if (Tags.Length == 0)
+                if (Tags == null || Tags.Length == 0)
                 {
                     fs.WriteLine("  - ");
                 }

--- a/src/JournalCli/Commands/NewJournalEntryCmdlet.cs
+++ b/src/JournalCli/Commands/NewJournalEntryCmdlet.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
-using System.IO;
+using System.IO.Abstractions;
 using System.Management.Automation;
 using JetBrains.Annotations;
 
@@ -19,22 +19,24 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var root = GetResolvedRootDirectory();
+            base.ProcessRecord();
+            
             var entryDate = DateTime.Today.AddDays(DateOffset);
             var year = entryDate.Year.ToString();
             var month = $"{entryDate.Month:00} {entryDate:MMMM}";
-            var parent = Path.Combine(root, year, month);
+            var fileSystem = new FileSystem();
+            var parent = fileSystem.Path.Combine(RootDirectory, year, month);
 
-            if (!Directory.Exists(parent))
-                Directory.CreateDirectory(parent);
+            if (!fileSystem.Directory.Exists(parent))
+                fileSystem.Directory.CreateDirectory(parent);
 
             var fileName = entryDate.ToString("yyyy.MM.dd.'md'");
-            var fullPath = Path.Combine(parent, fileName);
+            var fullPath = fileSystem.Path.Combine(parent, fileName);
 
-            if (File.Exists(fullPath))
+            if (fileSystem.File.Exists(fullPath))
                 ThrowTerminatingError($"File already exists: '{fullPath}'", ErrorCategory.InvalidOperation);
 
-            using (var fs = File.CreateText(fullPath))
+            using (var fs = fileSystem.File.CreateText(fullPath))
             {
                 fs.WriteLine("---");
                 fs.WriteLine("tags:");

--- a/src/JournalCli/Commands/OpenBackupLocationCmdlet.cs
+++ b/src/JournalCli/Commands/OpenBackupLocationCmdlet.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics;
-using System.IO;
+using System.IO.Abstractions;
 using System.Management.Automation;
 using JetBrains.Annotations;
 
@@ -11,8 +11,10 @@ namespace JournalCli.Commands
     {
         protected override void ProcessRecord()
         {
-            var path = UserSettings.Load().BackupLocation;
-            if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+            var fileSystem = new FileSystem();
+            var encryptedStore = EncryptedStoreFactory.Create();
+            var path = UserSettings.Load(encryptedStore).BackupLocation;
+            if (!string.IsNullOrEmpty(path) && fileSystem.Directory.Exists(path))
             {
                 Process.Start(new ProcessStartInfo(path)
                 {
@@ -21,7 +23,7 @@ namespace JournalCli.Commands
             }
             else
             {
-                ThrowTerminatingError("Backup location not found", ErrorCategory.InvalidOperation);
+                throw new PSInvalidOperationException("Backup location not found");
             }
         }
     }

--- a/src/JournalCli/Commands/OpenBackupLocationCmdlet.cs
+++ b/src/JournalCli/Commands/OpenBackupLocationCmdlet.cs
@@ -12,7 +12,7 @@ namespace JournalCli.Commands
         protected override void ProcessRecord()
         {
             var fileSystem = new FileSystem();
-            var encryptedStore = EncryptedStoreFactory.Create();
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var path = UserSettings.Load(encryptedStore).BackupLocation;
             if (!string.IsNullOrEmpty(path) && fileSystem.Directory.Exists(path))
             {

--- a/src/JournalCli/Commands/OpenRandomJournalEntryCmdlet.cs
+++ b/src/JournalCli/Commands/OpenRandomJournalEntryCmdlet.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.IO.Abstractions;
+using System.Management.Automation;
 using JetBrains.Annotations;
 
 namespace JournalCli.Commands
@@ -13,11 +14,13 @@ namespace JournalCli.Commands
         protected override void ProcessRecord()
         {
             base.ProcessRecord();
+            var fileSystem = new FileSystem();
+            var journal = Journal.Open(fileSystem, RootDirectory);
 
-            if (Tags.Length == 0)
-                Journal.OpenRandomEntry(RootDirectory);
+            if (Tags == null || Tags.Length == 0)
+                journal.OpenRandomEntry();
             else
-                Journal.OpenRandomEntry(RootDirectory, Tags);
+                journal.OpenRandomEntry(Tags);
         }
     }
 }

--- a/src/JournalCli/Commands/OpenRandomJournalEntryCmdlet.cs
+++ b/src/JournalCli/Commands/OpenRandomJournalEntryCmdlet.cs
@@ -12,12 +12,12 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var root = GetResolvedRootDirectory();
+            base.ProcessRecord();
 
             if (Tags.Length == 0)
-                Journal.OpenRandomEntry(root);
+                Journal.OpenRandomEntry(RootDirectory);
             else
-                Journal.OpenRandomEntry(root, Tags);
+                Journal.OpenRandomEntry(RootDirectory, Tags);
         }
     }
 }

--- a/src/JournalCli/Commands/RemoveBackupJournalFilesCmdlet.cs
+++ b/src/JournalCli/Commands/RemoveBackupJournalFilesCmdlet.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-using System.IO;
+using System.IO.Abstractions;
 using System.Management.Automation;
 using JetBrains.Annotations;
+using SysIO = System.IO;
 
 namespace JournalCli.Commands
 {
@@ -18,6 +19,8 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
+            base.ProcessRecord();
+
             if (!DryRun)
                 WriteHost(_warning, ConsoleColor.Red);
 
@@ -25,7 +28,8 @@ namespace JournalCli.Commands
             if (!DryRun && !ShouldContinue("Do you want to continue?", $"Deleting '{Constants.BackupFileExtension}' files..."))
                 return;
 
-            var backupFiles = Directory.GetFiles(GetResolvedRootDirectory(), $"*{Constants.BackupFileExtension}", SearchOption.AllDirectories);
+            var fileSystem = new FileSystem();
+            var backupFiles = fileSystem.Directory.GetFiles(RootDirectory, $"*{Constants.BackupFileExtension}", SysIO.SearchOption.AllDirectories);
 
             if (DryRun)
             {
@@ -42,7 +46,7 @@ namespace JournalCli.Commands
             {
                 foreach (var backupFile in backupFiles)
                 {
-                    File.Delete(backupFile);
+                    fileSystem.File.Delete(backupFile);
                     WriteHost($"Deleted: {backupFile}", ConsoleColor.Red);
                 }
 

--- a/src/JournalCli/Commands/RenameJournalTagCmdlet.cs
+++ b/src/JournalCli/Commands/RenameJournalTagCmdlet.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
@@ -25,6 +26,8 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
+            base.ProcessRecord();
+
             if (!DryRun && NoBackups)
             {
                 var warning = "***** Hey, you! *****\r\n" +
@@ -36,7 +39,7 @@ namespace JournalCli.Commands
             if (!DryRun && !ShouldContinue("Do you want to continue?", $"Renaming '{OldName}' tags to '{NewName}'..."))
                 return;
 
-            var index = Journal.CreateIndex(GetResolvedRootDirectory(), false);
+            var index = Journal.CreateIndex(RootDirectory, false);
             var journalEntries = index.SingleOrDefault(x => x.Tag == OldName);
 
             if (journalEntries == null)
@@ -64,7 +67,8 @@ namespace JournalCli.Commands
                     continue;
                 }
 
-                var file = new JournalEntryFile(journalEntry.FilePath);
+                var fileSystem = new FileSystem();
+                var file = new JournalEntryFile(fileSystem, journalEntry.FilePath);
                 var currentTags = file.GetTags().ToList();
                 var oldItemIndex = currentTags.IndexOf(OldName);
                 currentTags[oldItemIndex] = NewName;

--- a/src/JournalCli/Commands/RenameJournalTagCmdlet.cs
+++ b/src/JournalCli/Commands/RenameJournalTagCmdlet.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
-using System.Text;
 using JetBrains.Annotations;
 
 namespace JournalCli.Commands
@@ -39,7 +37,9 @@ namespace JournalCli.Commands
             if (!DryRun && !ShouldContinue("Do you want to continue?", $"Renaming '{OldName}' tags to '{NewName}'..."))
                 return;
 
-            var index = Journal.CreateIndex(RootDirectory, false);
+            var fileSystem = new FileSystem();
+            var journal = Journal.Open(fileSystem, RootDirectory);
+            var index = journal.CreateIndex(false);
             var journalEntries = index.SingleOrDefault(x => x.Tag == OldName);
 
             if (journalEntries == null)
@@ -67,7 +67,6 @@ namespace JournalCli.Commands
                     continue;
                 }
 
-                var fileSystem = new FileSystem();
                 var file = new JournalEntryFile(fileSystem, journalEntry.FilePath);
                 var currentTags = file.GetTags().ToList();
                 var oldItemIndex = currentTags.IndexOf(OldName);

--- a/src/JournalCli/Commands/SetDefaultJournalLocationCmdlet.cs
+++ b/src/JournalCli/Commands/SetDefaultJournalLocationCmdlet.cs
@@ -12,7 +12,7 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var encryptedStore = EncryptedStoreFactory.Create();
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
             settings.DefaultJournalRoot = Location;
             settings.Save(encryptedStore);

--- a/src/JournalCli/Commands/SetDefaultJournalLocationCmdlet.cs
+++ b/src/JournalCli/Commands/SetDefaultJournalLocationCmdlet.cs
@@ -12,9 +12,10 @@ namespace JournalCli.Commands
 
         protected override void ProcessRecord()
         {
-            var settings = UserSettings.Load();
+            var encryptedStore = EncryptedStoreFactory.Create();
+            var settings = UserSettings.Load(encryptedStore);
             settings.DefaultJournalRoot = Location;
-            settings.Save();
+            settings.Save(encryptedStore);
         }
     }
 }

--- a/src/JournalCli/EncryptedStore.cs
+++ b/src/JournalCli/EncryptedStore.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.IO.Abstractions;
 
 namespace JournalCli
 {
@@ -8,12 +8,13 @@ namespace JournalCli
         protected EncryptedStore()
         {
             var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var path = Path.Combine(appData, "JournalCli");
+            var fileSystem = new FileSystem();
+            var path = fileSystem.Path.Combine(appData, "JournalCli");
             StorageLocation = path;
         }
 
         protected readonly string StorageLocation;
         public abstract void Save<T>(T target);
-        public abstract T Load<T>() where T : class;
+        public abstract T Load<T>() where T : class, new();
     }
 }

--- a/src/JournalCli/EncryptedStore.cs
+++ b/src/JournalCli/EncryptedStore.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.IO;
+
+namespace JournalCli
+{
+    internal abstract class EncryptedStore : IEncryptedStore
+    {
+        protected EncryptedStore()
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            var path = Path.Combine(appData, "JournalCli");
+            StorageLocation = path;
+        }
+
+        protected readonly string StorageLocation;
+        public abstract void Save<T>(T target);
+        public abstract T Load<T>() where T : class;
+    }
+}

--- a/src/JournalCli/EncryptedStore.cs
+++ b/src/JournalCli/EncryptedStore.cs
@@ -3,7 +3,8 @@ using System.IO.Abstractions;
 
 namespace JournalCli
 {
-    internal abstract class EncryptedStore : IEncryptedStore
+    internal abstract class EncryptedStore<T> : IEncryptedStore<T>
+        where T : class, new()
     {
         protected EncryptedStore()
         {
@@ -14,7 +15,7 @@ namespace JournalCli
         }
 
         protected readonly string StorageLocation;
-        public abstract void Save<T>(T target);
-        public abstract T Load<T>() where T : class, new();
+        public abstract void Save(T target);
+        public abstract T Load();
     }
 }

--- a/src/JournalCli/EncryptedStoreFactory.cs
+++ b/src/JournalCli/EncryptedStoreFactory.cs
@@ -1,15 +1,17 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 
 namespace JournalCli
 {
     internal class EncryptedStoreFactory
     {
-        public IEncryptedStore Create()
+        public static IEncryptedStore Create()
         {
+            var fileSystem = new FileSystem();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return new WindowsEncryptedStore();
+                return new WindowsEncryptedStore(fileSystem);
 
-            return new MacEncryptedStore();
+            return new MacEncryptedStore(fileSystem);
         }
     }
 }

--- a/src/JournalCli/EncryptedStoreFactory.cs
+++ b/src/JournalCli/EncryptedStoreFactory.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.InteropServices;
+
+namespace JournalCli
+{
+    internal class EncryptedStoreFactory
+    {
+        public IEncryptedStore Create()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return new WindowsEncryptedStore();
+
+            return new MacEncryptedStore();
+        }
+    }
+}

--- a/src/JournalCli/EncryptedStoreFactory.cs
+++ b/src/JournalCli/EncryptedStoreFactory.cs
@@ -5,13 +5,14 @@ namespace JournalCli
 {
     internal class EncryptedStoreFactory
     {
-        public static IEncryptedStore Create()
+        public static IEncryptedStore<T> Create<T>()
+            where T : class, new()
         {
             var fileSystem = new FileSystem();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return new WindowsEncryptedStore(fileSystem);
+                return new WindowsEncryptedStore<T>(fileSystem);
 
-            return new MacEncryptedStore(fileSystem);
+            return new MacEncryptedStore<T>(fileSystem);
         }
     }
 }

--- a/src/JournalCli/IEncryptedStore.cs
+++ b/src/JournalCli/IEncryptedStore.cs
@@ -1,0 +1,8 @@
+﻿namespace JournalCli
+{
+    internal interface IEncryptedStore
+    {
+        void Save<T>(T target);
+        T Load<T>() where T : class;
+    }
+}

--- a/src/JournalCli/IEncryptedStore.cs
+++ b/src/JournalCli/IEncryptedStore.cs
@@ -3,6 +3,6 @@
     internal interface IEncryptedStore
     {
         void Save<T>(T target);
-        T Load<T>() where T : class;
+        T Load<T>() where T : class, new();
     }
 }

--- a/src/JournalCli/IEncryptedStore.cs
+++ b/src/JournalCli/IEncryptedStore.cs
@@ -1,8 +1,9 @@
 ﻿namespace JournalCli
 {
-    internal interface IEncryptedStore
+    internal interface IEncryptedStore<T>
+        where T : class, new()
     {
-        void Save<T>(T target);
-        T Load<T>() where T : class, new();
+        void Save(T target);
+        T Load();
     }
 }

--- a/src/JournalCli/Journal.cs
+++ b/src/JournalCli/Journal.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
-using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
+using SysIO = System.IO;
 
 namespace JournalCli
 {
@@ -28,8 +29,9 @@ namespace JournalCli
 
         public static void OpenRandomEntry(string rootDirectory)
         {
-            var di = new DirectoryInfo(rootDirectory);
-            var entries = di.GetFiles("*.md", SearchOption.AllDirectories).ToList();
+            var fileSystem = new FileSystem();
+            var di = fileSystem.DirectoryInfo.FromDirectoryName(rootDirectory);
+            var entries = di.GetFiles("*.md", SysIO.SearchOption.AllDirectories).ToList();
 
             if (entries.Count == 0)
                 throw new PSInvalidOperationException("I couldn't find any journal entries. Did you pass in the right root directory?");
@@ -44,10 +46,11 @@ namespace JournalCli
         public static JournalIndex CreateIndex(string rootDirectory, bool includeHeaders)
         {
             var index = new JournalIndex();
+            var fileSystem = new FileSystem();
 
-            foreach (var file in MarkdownFiles.FindAll(rootDirectory))
+            foreach (var file in MarkdownFiles.FindAll(fileSystem, rootDirectory))
             {
-                var entry = new JournalEntry(file, includeHeaders);
+                var entry = new JournalEntry(fileSystem, file, includeHeaders);
                 foreach (var tag in entry.Tags)
                 {
                     if (index.Contains(tag))

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AuthenticatedEncryption" Version="1.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="SharpZipLib" Version="1.0.0" />

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -22,12 +22,12 @@
 
   <ItemGroup>
     <PackageReference Include="AuthenticatedEncryption" Version="1.0.1" />
-    <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageReference Include="SharpZipLib" Version="1.0.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="6.0.21" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="6.0.23" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
-    <PackageReference Include="YamlDotNet" Version="5.3.0" />
+    <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="SharpZipLib" Version="1.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="6.0.21" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="5.3.0" />
   </ItemGroup>

--- a/src/JournalCli/JournalEntry.cs
+++ b/src/JournalCli/JournalEntry.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
+using System.IO.Abstractions;
 
 namespace JournalCli
 {
     public class JournalEntry
     {
-        public JournalEntry(string filePath, bool includeHeaders)
+        private readonly IFileSystem _fileSystem;
+
+        public JournalEntry(IFileSystem fileSystem, string filePath, bool includeHeaders)
         {
+            _fileSystem = fileSystem;
             FilePath = filePath;
-            var entryFile = new JournalEntryFile(filePath);
+            var entryFile = new JournalEntryFile(fileSystem, filePath);
             Tags = entryFile.GetTags();
 
             if (includeHeaders)
@@ -22,6 +25,6 @@ namespace JournalCli
 
         public ICollection<string> Headers { get; set; }
 
-        public override string ToString() => Path.GetFileNameWithoutExtension(FilePath) ?? throw new InvalidOperationException();
+        public override string ToString() => _fileSystem.Path.GetFileNameWithoutExtension(FilePath) ?? throw new InvalidOperationException();
     }
 }

--- a/src/JournalCli/MacEncryptedStore.cs
+++ b/src/JournalCli/MacEncryptedStore.cs
@@ -6,7 +6,8 @@ namespace JournalCli
 {
     using AuthenticatedEncryption;
 
-    internal class MacEncryptedStore : EncryptedStore
+    internal class MacEncryptedStore<T> : EncryptedStore<T>
+        where T : class, new()
     {
         private readonly IFileSystem _fileSystem;
         private readonly string _cryptKeyPath;
@@ -28,7 +29,7 @@ namespace JournalCli
             }
         }
 
-        public override void Save<T>(T target)
+        public override void Save(T target)
         {
             var serializer = new SerializerBuilder().Build();
             var yaml = serializer.Serialize(target);
@@ -40,7 +41,7 @@ namespace JournalCli
             _fileSystem.File.WriteAllText(cipherPath, cipherText);
         }
 
-        public override T Load<T>()
+        public override T Load()
         {
             try
             {

--- a/src/JournalCli/MacEncryptedStore.cs
+++ b/src/JournalCli/MacEncryptedStore.cs
@@ -21,6 +21,7 @@ namespace JournalCli
 
             if (!_fileSystem.File.Exists(_cryptKeyPath) || !_fileSystem.File.Exists(_authKeyPath))
             {
+                fileSystem.Directory.CreateDirectory(StorageLocation);
                 var cryptKey = AuthenticatedEncryption.NewKey();
                 var authKey = AuthenticatedEncryption.NewKey();
 

--- a/src/JournalCli/MacEncryptedStore.cs
+++ b/src/JournalCli/MacEncryptedStore.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using YamlDotNet.Serialization;
+
+namespace JournalCli
+{
+    using AuthenticatedEncryption;
+
+    internal class MacEncryptedStore : EncryptedStore
+    {
+        private readonly string _cryptKeyPath;
+        private readonly string _authKeyPath;
+        private readonly string _cipherPath;
+
+        public MacEncryptedStore()
+        {
+            _cryptKeyPath = Path.Combine(StorageLocation, "ck");
+            _authKeyPath = Path.Combine(StorageLocation, "ak");
+            _cipherPath = Path.Combine(StorageLocation, "c");
+
+            if (!File.Exists(_cryptKeyPath) || !File.Exists(_authKeyPath))
+            {
+                var cryptKey = AuthenticatedEncryption.NewKey();
+                var authKey = AuthenticatedEncryption.NewKey();
+
+                File.WriteAllBytes(_cryptKeyPath, cryptKey);
+                File.WriteAllBytes(_authKeyPath, authKey);
+            }
+        }
+
+        public override void Save<T>(T target)
+        {
+            var serializer = new SerializerBuilder().Build();
+            var yaml = serializer.Serialize(target);
+
+            var cryptKey = File.ReadAllBytes(_cryptKeyPath);
+            var authKey = File.ReadAllBytes(_authKeyPath);
+            var cipherText = AuthenticatedEncryption.Encrypt(yaml, cryptKey, authKey);
+            File.WriteAllText(_cipherPath, cipherText);
+        }
+
+        public override T Load<T>()
+        {
+            var cryptKey = File.ReadAllBytes(_cryptKeyPath);
+            var authKey = File.ReadAllBytes(_authKeyPath);
+            var cipherText = File.ReadAllText(_cipherPath);
+            var plainText = AuthenticatedEncryption.Decrypt(cipherText, cryptKey, authKey);
+            var deserializer = new DeserializerBuilder().Build();
+            return deserializer.Deserialize<T>(plainText);
+        }
+    }
+}

--- a/src/JournalCli/MarkdownFiles.cs
+++ b/src/JournalCli/MarkdownFiles.cs
@@ -1,27 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.Collections.Generic;
+using System.IO.Abstractions;
+using SysIO = System.IO;
 using System.Linq;
 
 namespace JournalCli
 {
     public class MarkdownFiles
     {
-        private const FileAttributes Attributes = FileAttributes.Hidden | FileAttributes.System;
+        private const SysIO.FileAttributes Attributes = SysIO.FileAttributes.Hidden | SysIO.FileAttributes.System;
 
-        public static List<string> FindAll(string rootDirectory)
+        public static List<string> FindAll(IFileSystem fileSystem, string rootDirectory)
         {
-            var root = new DirectoryInfo(rootDirectory);
+            var root = fileSystem.DirectoryInfo.FromDirectoryName(rootDirectory);
             var allFiles = new List<string>();
 
             foreach (var dir in root.EnumerateDirectories().Where(d => (d.Attributes & Attributes) == 0))
             {
-                var result = FindAll(dir.FullName);
+                var result = FindAll(fileSystem, dir.FullName);
                 allFiles.AddRange(result);
             }
 
-            var files = Directory.GetFiles(rootDirectory, "*.md");
+            var files = fileSystem.Directory.GetFiles(rootDirectory, "*.md");
             allFiles.AddRange(files);
             return allFiles;
         }

--- a/src/JournalCli/UserSettings.cs
+++ b/src/JournalCli/UserSettings.cs
@@ -2,7 +2,7 @@
 {
     internal class UserSettings
     {
-        public static UserSettings Load(IEncryptedStore encryptedStore) => encryptedStore.Load<UserSettings>();
+        public static UserSettings Load(IEncryptedStore<UserSettings> encryptedStore) => encryptedStore.Load();
 
         public string DefaultJournalRoot { get; set; }
 
@@ -10,6 +10,6 @@
 
         public string BackupPassword { get; set; }
 
-        public void Save(IEncryptedStore encryptedStore) => encryptedStore.Save(this);
+        public void Save(IEncryptedStore<UserSettings> encryptedStore) => encryptedStore.Save(this);
     }
 }

--- a/src/JournalCli/UserSettings.cs
+++ b/src/JournalCli/UserSettings.cs
@@ -1,42 +1,8 @@
-﻿using System;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
-using YamlDotNet.Serialization;
-
-namespace JournalCli
+﻿namespace JournalCli
 {
-    public class UserSettings
+    internal class UserSettings
     {
-        private static readonly string CipherPath;
-        private static readonly string EntropyPath;
-        private static readonly string StorageLocation;
-
-        static UserSettings()
-        {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var path = Path.Combine(appData, "JournalCli");
-            StorageLocation = path;
-            CipherPath = Path.Combine(StorageLocation, "c");
-            EntropyPath = Path.Combine(StorageLocation, "e");
-        }
-
-        public static bool Exists() => File.Exists(CipherPath) && File.Exists(EntropyPath);
-
-        public static UserSettings Load()
-        {
-            if (!Exists())
-                return new UserSettings();
-
-            var cipher = File.ReadAllBytes(CipherPath);
-            var entropy = File.ReadAllBytes(EntropyPath);
-
-            var resultBytes = ProtectedData.Unprotect(cipher, entropy, DataProtectionScope.CurrentUser);
-            var yaml = Encoding.UTF8.GetString(resultBytes);
-
-            var deserializer = new DeserializerBuilder().Build();
-            return deserializer.Deserialize<UserSettings>(yaml);
-        }
+        public static UserSettings Load(IEncryptedStore encryptedStore) => encryptedStore.Load<UserSettings>();
 
         public string DefaultJournalRoot { get; set; }
 
@@ -44,22 +10,6 @@ namespace JournalCli
 
         public string BackupPassword { get; set; }
 
-        public void Save()
-        {
-            var serializer = new SerializerBuilder().Build();
-            var yaml = serializer.Serialize(this);
-
-            var tokenBytes = Encoding.UTF8.GetBytes(yaml);
-
-            var entropy = new byte[255];
-            using (var rng = new RNGCryptoServiceProvider())
-                rng.GetBytes(entropy);
-
-            var cipher = ProtectedData.Protect(tokenBytes, entropy, DataProtectionScope.CurrentUser);
-
-            Directory.CreateDirectory(StorageLocation);
-            File.WriteAllBytes(CipherPath, cipher);
-            File.WriteAllBytes(EntropyPath, entropy);
-        }
+        public void Save(IEncryptedStore encryptedStore) => encryptedStore.Save(this);
     }
 }

--- a/src/JournalCli/UserSettings.cs
+++ b/src/JournalCli/UserSettings.cs
@@ -1,6 +1,10 @@
-﻿namespace JournalCli
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace JournalCli
 {
-    internal class UserSettings
+    [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
+    internal class UserSettings : IEquatable<UserSettings>
     {
         public static UserSettings Load(IEncryptedStore<UserSettings> encryptedStore) => encryptedStore.Load();
 
@@ -11,5 +15,33 @@
         public string BackupPassword { get; set; }
 
         public void Save(IEncryptedStore<UserSettings> encryptedStore) => encryptedStore.Save(this);
+
+        public bool Equals(UserSettings other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(DefaultJournalRoot, other.DefaultJournalRoot) && 
+                string.Equals(BackupLocation, other.BackupLocation) &&
+                string.Equals(BackupPassword, other.BackupPassword);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((UserSettings)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = DefaultJournalRoot != null ? DefaultJournalRoot.GetHashCode() : 0;
+                hashCode = (hashCode * 397) ^ (BackupLocation != null ? BackupLocation.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (BackupPassword != null ? BackupPassword.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/src/JournalCli/WindowsEncryptedStore.cs
+++ b/src/JournalCli/WindowsEncryptedStore.cs
@@ -6,7 +6,8 @@ using YamlDotNet.Serialization;
 
 namespace JournalCli
 {
-    internal class WindowsEncryptedStore : EncryptedStore
+    internal class WindowsEncryptedStore<T> : EncryptedStore<T>
+        where T : class, new()
     {
         private readonly IFileSystem _fileSystem;
         private readonly string _entropyPath;
@@ -17,7 +18,7 @@ namespace JournalCli
             _entropyPath = _fileSystem.Path.Combine(StorageLocation, "e");
         }
 
-        public override void Save<T>(T target)
+        public override void Save(T target)
         {
             var serializer = new SerializerBuilder().Build();
             var yaml = serializer.Serialize(target);
@@ -35,7 +36,7 @@ namespace JournalCli
             _fileSystem.File.WriteAllBytes(_entropyPath, entropy);
         }
 
-        public override T Load<T>()
+        public override T Load()
         {
             var cipherPath = _fileSystem.Path.Combine(StorageLocation, typeof(T).FullName);
             if (!_fileSystem.File.Exists(cipherPath) || !_fileSystem.File.Exists(_entropyPath))

--- a/src/JournalCli/WindowsEncryptedStore.cs
+++ b/src/JournalCli/WindowsEncryptedStore.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using YamlDotNet.Serialization;
+
+namespace JournalCli
+{
+    internal class WindowsEncryptedStore : EncryptedStore
+    {
+        private readonly string _cipherPath;
+        private readonly string _entropyPath;
+
+        public WindowsEncryptedStore()
+        {
+            _cipherPath = Path.Combine(StorageLocation, "c");
+            _entropyPath = Path.Combine(StorageLocation, "e");
+        }
+
+        public override void Save<T>(T target)
+        {
+            var serializer = new SerializerBuilder().Build();
+            var yaml = serializer.Serialize(target);
+            var tokenBytes = Encoding.UTF8.GetBytes(yaml);
+
+            var entropy = new byte[255];
+            using (var rng = new RNGCryptoServiceProvider())
+                rng.GetBytes(entropy);
+
+            var cipher = ProtectedData.Protect(tokenBytes, entropy, DataProtectionScope.CurrentUser);
+
+            Directory.CreateDirectory(StorageLocation);
+            File.WriteAllBytes(_cipherPath, cipher);
+            File.WriteAllBytes(_entropyPath, entropy);
+        }
+
+        public override T Load<T>()
+        {
+            if (!File.Exists(_cipherPath) || !File.Exists(_entropyPath))
+                return null;
+
+            var cipher = File.ReadAllBytes(_cipherPath);
+            var entropy = File.ReadAllBytes(_entropyPath);
+
+            var resultBytes = ProtectedData.Unprotect(cipher, entropy, DataProtectionScope.CurrentUser);
+            var yaml = Encoding.UTF8.GetString(resultBytes);
+
+            var deserializer = new DeserializerBuilder().Build();
+            return deserializer.Deserialize<T>(yaml);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The previous release included an encryption package that (turns out) only works on Windows. This PR initially began as a remedy to that flaw, and ended up including a large amount of refactoring. 

# Details
- User settings are now encrypted on disk in a platform specific way.
- I swapped out all references to `System.IO` with `System.IO.Abstractions` so that IO functionality could be mocked and tested.
- Fixed a null reference exception when no tags are provided to `New-JournalEntry`.
- General refactorings to improve testability.