### PR TITLE
Patch: Fix incorrect password for backup sets

### DIFF
--- a/src/JournalCli/Cmdlets/BackupJournalCmdlet.cs
+++ b/src/JournalCli/Cmdlets/BackupJournalCmdlet.cs
@@ -52,7 +52,7 @@ namespace JournalCli.Cmdlets
             var fileName = $"{DateTime.Now:yyyy.MM.dd.H.mm.ss.FFF}.zip";
             var destinationPath = fileSystem.Path.Combine(BackupLocation, fileName);
 
-            var zip = new FastZip { CreateEmptyDirectories = true, Password = Password };
+            var zip = new FastZip { CreateEmptyDirectories = true, Password = settings.BackupPassword };
             zip.CreateZip(destinationPath, RootDirectory, true, null);
         }
     }


### PR DESCRIPTION
When the backup password was loaded from settings, as opposed to being provided on the command line, it was provided to the `FastZip` class. This resulted in backup sets that were not password protected.