### PR TITLE
v1.2.2: General improvements to Get-ReadmeEntries, Rename-JournalTag, and New-JournalEntry cmdlets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.1
+version: 1.2.2
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/src/JournalCli/Cmdlets/CmdletBase.cs
+++ b/src/JournalCli/Cmdlets/CmdletBase.cs
@@ -1,11 +1,17 @@
 ﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Reflection;
 using JournalCli.Infrastructure;
 
 namespace JournalCli.Cmdlets
 {
     public abstract class CmdletBase : PSCmdlet
     {
+        private readonly Lazy<string> _assemblyName = new Lazy<string>(() => Assembly.GetExecutingAssembly().FullName);
+
         protected string ResolvePath(string path) => GetUnresolvedProviderPathFromPSPath(path);
 
         protected void ThrowTerminatingError(string message, ErrorCategory category)
@@ -21,20 +27,69 @@ namespace JournalCli.Cmdlets
         /// <returns>True if the user wants to proceed. False if they want to abort.</returns>
         protected bool AreYouSure(string warning) => ShouldContinue("Are you certain you want to continue?", "ACTION: " + warning);
 
-        protected void WriteHeader(string title, ConsoleColor color)
-        {
-            var windowWidth = Host.UI.RawUI.WindowSize.Width;
-            var headerWidth = Math.Min(75, windowWidth);
+        /// <summary>
+        /// Sends and informational message to the pipeline.
+        /// </summary>
+        /// <param name="message"></param>
+        protected void WriteInformation(string message) => WriteInformation(new InformationRecord(message, _assemblyName.Value));
 
-            WriteHost(new string('=', headerWidth), color);
-            WriteHost(title.Wrap(75), color);
-            WriteHost(new string('=', headerWidth), color);
+        /// <summary>
+        /// Prints a message to the PowerShell host.
+        /// </summary>
+        protected void WriteHost(string message) => Host.UI.WriteLine(message);
+
+        /// <summary>
+        /// Prints a message to the PowerShell host with the specified fore- and background colors.
+        /// </summary>
+        protected void WriteHost(string message, ConsoleColor backgroundColor, ConsoleColor foregroundColor) =>
+            Host.UI.WriteLine(foregroundColor, backgroundColor, message);
+
+        /// <summary>
+        /// Prints a message to the PowerShell host with the fore- and background colors inverted.
+        /// </summary>
+        protected void WriteHostInverted(string message) => Host.UI.WriteLine(Host.UI.RawUI.BackgroundColor, Host.UI.RawUI.ForegroundColor, message);
+
+        /// <summary>
+        /// Asks the user a yes or no question and returns true if the user selects yes, or false for no.
+        /// </summary>
+        /// <param name="question">A question to ask the user. Include a question mark at the end.</param>
+        protected bool YesOrNo(string question)
+        {
+            return YesOrNo(question, Host.UI.RawUI.BackgroundColor, Host.UI.RawUI.ForegroundColor);
         }
 
-        protected void WriteHost(string text, ConsoleColor foregroundColor = ConsoleColor.White, ConsoleColor backgroundColor = ConsoleColor.Black)
+        /// <summary>
+        /// Asks the user a yes or no question and returns true if the user selects yes, or false for no.
+        /// </summary>
+        /// <param name="question">A question to ask the user. Include a question mark at the end.</param>
+        /// <param name="foreground">The foreground color to use.</param>
+        /// <param name="background">The background color to use.</param>
+        protected bool YesOrNo(string question, ConsoleColor foreground, ConsoleColor background)
         {
-            Host.UI.WriteLine(foregroundColor, backgroundColor, text);
+            KeyInfo key;
+            do
+            {
+                Host.UI.Write(foreground, background, $" {question} (y/n) ");
+                key = Host.UI.RawUI.ReadKey();
+                Host.UI.WriteLine();
+            } while (key.Character != 'y' && key.Character != 'n');
+
+            return key.Character == 'y';
         }
 
+        /// <summary>
+        /// Presents the user with an ordered list of options to choose from and returns the index of the selection.
+        /// </summary>
+        /// <param name="caption">The title to display.</param>
+        /// <param name="message">The message body to display. </param>
+        /// <param name="defaultChoice">The index of the value in 'choices' which should be the default.</param>
+        /// <param name="choices">A list of strings which represent choices. Insert an ampersand before a single letter of
+        /// each item to be used as a shortcut key. Example: ("&amp;one", &amp;two", "t&amp;hree"), where 'O' would be
+        /// the shortcut for "one", 'T' for "two", and 'H' for "three".</param>
+        protected int Choice(string caption, string message, int defaultChoice, params string[] choices)
+        {
+            var choiceDescriptions = choices.Select(c => new ChoiceDescription(c)).ToList();
+            return Host.UI.PromptForChoice(caption, message, new Collection<ChoiceDescription>(choiceDescriptions), defaultChoice);
+        }
     }
 }

--- a/src/JournalCli/Cmdlets/GetReadmeEntriesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetReadmeEntriesCmdlet.cs
@@ -8,7 +8,7 @@ using JournalCli.Infrastructure;
 namespace JournalCli.Cmdlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "ReadmeEntries")]
+    [Cmdlet(VerbsCommon.Get, "ReadmeEntries", DefaultParameterSetName = "All")]
     [OutputType(typeof(ReadmeJournalEntryCollection))]
     public class GetReadmeEntriesCmdlet : JournalCmdletBase
     {
@@ -42,7 +42,7 @@ namespace JournalCli.Cmdlets
         {
             get
             {
-                if (All)
+                if (All || ParameterSetName == "All")
                     return new NodaTime.LocalDate();
 
                 switch (Period)

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -58,6 +58,10 @@ namespace JournalCli.Cmdlets
 
         private void CommitCore(string message)
         {
+#if DEBUG
+            if (System.Diagnostics.Debugger.IsAttached)
+                return;
+#endif
             using (var repo = new Git.Repository(Location))
             {
                 var statusOptions = new Git.StatusOptions

--- a/src/JournalCli/Cmdlets/RenameJournalTagCmdlet.cs
+++ b/src/JournalCli/Cmdlets/RenameJournalTagCmdlet.cs
@@ -60,7 +60,7 @@ namespace JournalCli.Cmdlets
             var consoleColor = DryRun ? ConsoleColor.DarkGreen : ConsoleColor.Yellow;
             foreach (var file in effectedEntries)
             {
-                WriteHost($"{counter++.ToString().PadLeft(3)}) {file}", consoleColor);
+                WriteHost($"{counter++.ToString().PadLeft(3)}) {file}", ConsoleColor.Black, consoleColor);
             }
         }
     }

--- a/src/JournalCli/Core/Journal.cs
+++ b/src/JournalCli/Core/Journal.cs
@@ -73,7 +73,7 @@ namespace JournalCli.Core
             return readmeCollection;
         }
 
-        public IEnumerable<string> RenameTagDryRun(string oldName)
+        public ICollection<string> RenameTagDryRun(string oldName)
         {
             var index = CreateIndex<JournalEntryFile>();
             var journalEntries = index.SingleOrDefault(x => x.Tag == oldName);
@@ -84,7 +84,7 @@ namespace JournalCli.Core
             return journalEntries.Entries.Select(e => e.EntryName).ToList();
         }
 
-        public IEnumerable<string> RenameTag(string oldName, string newName)
+        public ICollection<string> RenameTag(string oldName, string newName)
         {
             var index = CreateIndex<JournalEntryFile>();
             var journalEntries = index.SingleOrDefault(x => x.Tag == oldName);

--- a/src/JournalCli/Core/Journal.cs
+++ b/src/JournalCli/Core/Journal.cs
@@ -143,7 +143,7 @@ namespace JournalCli.Core
             var entryFilePath = journalWriter.GetJournalEntryFilePath(entryDate);
 
             if (journalWriter.EntryExists(entryFilePath))
-                throw new InvalidOperationException($"Journal entry already exists: '{entryFilePath}'");
+                throw new JournalEntryAlreadyExistsException(entryFilePath);
 
             var frontMatter = new JournalFrontMatter(tags, readme, entryDate);
             journalWriter.Create(frontMatter, entryFilePath, entryDate);

--- a/src/JournalCli/Infrastructure/JournalEntryAlreadyExistsException.cs
+++ b/src/JournalCli/Infrastructure/JournalEntryAlreadyExistsException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace JournalCli.Infrastructure
+{
+    public class JournalEntryAlreadyExistsException : Exception
+    {
+        private const string DefaultMessage = "Journal entry already exists.";
+
+        public JournalEntryAlreadyExistsException(string entryFilePath)
+            : base(DefaultMessage)
+        {
+            EntryFilePath = entryFilePath;
+        }
+
+        public JournalEntryAlreadyExistsException(string entryFilePath, string message) 
+            : base(message)
+        {
+            EntryFilePath = entryFilePath;
+        }
+
+        public JournalEntryAlreadyExistsException(string entryFilePath, string message, Exception innerException) 
+            : base(message, innerException)
+        {
+            EntryFilePath = entryFilePath;
+        }
+
+        public string EntryFilePath { get; }
+    }
+}

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile></DocumentationFile>
     <NoWarn></NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
- Use a reasonable default when running `Get-ReadmeEntries`, so no parameters are required.
- If a journal entry already exists when `New-JournalEntry` is executed, offer to open the entry for editing rather than throw an error.
- Improved the output of `Rename-JournalTag`. This is especially helpful when doing a DryRun on a tag that has many entries associated with it because you can now display the list output using normal PowerShell formatters, such as `Format-Wide`.