### PR TITLE
Add logging and automatic update checks

### DIFF
--- a/debug.ps1
+++ b/debug.ps1
@@ -4,7 +4,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-Remove-Item "$PSScriptRoot\publish\$ProjectName\*.*" -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item "$PSScriptRoot\publish\$ProjectName\" -Recurse -Force -ErrorAction SilentlyContinue
 $proj = Get-ChildItem -Filter "$ProjectName.csproj" -Recurse | Select-Object -First 1 -ExpandProperty FullName
 dotnet publish $proj -r 'win10-x64' --output "$PSScriptRoot\publish\$ProjectName" --self-contained true
 Import-Module "$PSScriptRoot\publish\$ProjectName\$ProjectName.dll"

--- a/src/JournalCli/Cmdlets/BackupJournalCmdlet.cs
+++ b/src/JournalCli/Cmdlets/BackupJournalCmdlet.cs
@@ -23,10 +23,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public SwitchParameter SaveParameters { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             var fileSystem = new FileSystem();
             var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);

--- a/src/JournalCli/Cmdlets/CmdletBase.cs
+++ b/src/JournalCli/Cmdlets/CmdletBase.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Host;
 using System.Reflection;
-using JournalCli.Core;
 using JournalCli.Infrastructure;
+using Serilog;
 
 namespace JournalCli.Cmdlets
 {
@@ -13,6 +14,16 @@ namespace JournalCli.Cmdlets
     {
         private readonly ISystemProcess _systemProcess = SystemProcessFactory.Create();
         private readonly Lazy<string> _assemblyName = new Lazy<string>(() => Assembly.GetExecutingAssembly().FullName);
+
+        protected CmdletBase()
+        {
+            // ReSharper disable AssignNullToNotNullAttribute
+            var path = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "logs", ".log");
+            // ReSharper restore AssignNullToNotNullAttribute
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.File(path, rollingInterval: RollingInterval.Day)
+                .CreateLogger();
+        }
 
         protected string ResolvePath(string path) => GetUnresolvedProviderPathFromPSPath(path);
 

--- a/src/JournalCli/Cmdlets/CmdletBase.cs
+++ b/src/JournalCli/Cmdlets/CmdletBase.cs
@@ -22,36 +22,6 @@ namespace JournalCli.Cmdlets
             ThrowTerminatingError(errorRecord);
         }
 
-        protected void CheckForUpdates()
-        {
-            // TODO: Catch all errors and log. This should never fail the app.
-
-            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
-            var settings = UserSettings.Load(encryptedStore);
-            if (settings.NextUpdateCheck != null && DateTime.Now <= settings.NextUpdateCheck)
-                return;
-
-            var installedVersionResult = ScriptBlock.Create("Get-Module JournalCli -ListAvailable | select version").Invoke();
-
-            // TODO: Possible IndexOutOfRange error 
-            var installedVersion = (Version)installedVersionResult[0].Properties["Version"].Value;
-
-            var availableVersionsResults = ScriptBlock.Create("Find-Module JournalCli | select version").Invoke();
-            var availableVersions = availableVersionsResults.Select(x => new Version((string)x.Properties["Version"].Value)).ToList();
-
-            var newVersion = availableVersions.FirstOrDefault(x => x.IsBeta() == installedVersion.IsBeta());
-
-            if (newVersion > installedVersion)
-            {
-                WriteHostInverted("***** Update Available! *****");
-                WriteHostInverted($"You're currently using version {installedVersion}. Run 'Update-Module JournalCli' " +
-                    $"to upgrade to version {newVersion}, or run 'Suspend-JournalCliUpdateChecks' to snooze these notifications.");
-            }
-
-            settings.NextUpdateCheck = DateTime.Now.AddDays(1);
-            settings.Save(encryptedStore);
-        }
-
         /// <summary>
         /// Prompts the user to confirm their actions before proceeding. 
         /// </summary>

--- a/src/JournalCli/Cmdlets/GetJournalEntriesByTagCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalEntriesByTagCmdlet.cs
@@ -30,10 +30,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public DateTime To { get; set; } = DateTime.Now;
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             var dateRange = GetRangeOrNull(From, To);
             var journal = OpenJournal();
 

--- a/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
@@ -22,9 +22,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public string[] Tags { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
             var dateRange = GetRangeOrNull(From, To);
 
             if (dateRange == null && Tags == null)

--- a/src/JournalCli/Cmdlets/GetJournalIndexCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalIndexCmdlet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
 using JetBrains.Annotations;
@@ -31,12 +30,10 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public DateTime To { get; set; } = DateTime.Now;
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
             var dateRange = GetRangeOrNull(From, To);
             var journal = OpenJournal();
-            
 
             if (IncludeBodies)
                 WriteResults<CompleteJournalEntry>(journal, dateRange);

--- a/src/JournalCli/Cmdlets/GetReadmeEntriesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetReadmeEntriesCmdlet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO.Abstractions;
 using System.Management.Automation;
 using JetBrains.Annotations;
 using JournalCli.Core;
@@ -25,10 +24,8 @@ namespace JournalCli.Cmdlets
         [Parameter(ParameterSetName = "All")]
         public SwitchParameter All { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             if (ParameterSetName == "Range")
             {
                 if (Duration == 0)
@@ -40,9 +37,9 @@ namespace JournalCli.Cmdlets
                 if (Duration < 0)
                 {
                     const string message = "If that was an attempt to look at FUTURE readme entries, nice try. ;) Although I discourage " +
-                        "looking at readme entries before they've expired (doing so seems to violate the spirit of writing a note " +
-                        "to your future self), I built a special switch for this use case. It's undocumented, but if you include " +
-                        "the -IncludeFuture switch, you'll get what you're after. Have fun!";
+                                           "looking at readme entries before they've expired (doing so seems to violate the spirit of writing a note " +
+                                           "to your future self), I built a special switch for this use case. It's undocumented, but if you include " +
+                                           "the -IncludeFuture switch, you'll get what you're after. Have fun!";
                     WriteWarning(message);
                     throw new PSArgumentOutOfRangeException(nameof(Duration), Duration, "Duration must be greater than or equal to 1.");
                 }

--- a/src/JournalCli/Cmdlets/GetRecentJournalEntriesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetRecentJournalEntriesCmdlet.cs
@@ -13,10 +13,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public int Limit { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             var fileSystem = new FileSystem();
             var readerWriterFactory = new JournalReaderWriterFactory(fileSystem, Location);
             var markdownFiles = new MarkdownFiles(fileSystem, Location);

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading;
@@ -21,7 +22,9 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public string Location { get; set; }
 
-        protected override void ProcessRecord()
+        protected abstract void RunJournalCommand();
+
+        protected sealed override void ProcessRecord()
         {
             if (!string.IsNullOrEmpty(Location))
             {

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JournalCli.Core;
 using JournalCli.Infrastructure;
+using Serilog;
 using Git = LibGit2Sharp;
 
 namespace JournalCli.Cmdlets
@@ -26,17 +27,19 @@ namespace JournalCli.Cmdlets
 
         protected sealed override void ProcessRecord()
         {
-            if (!string.IsNullOrEmpty(Location))
+            try
             {
-                Location = ResolvePath(Location);
-                return;
-            }
+                if (!string.IsNullOrEmpty(Location))
+                {
+                    Location = ResolvePath(Location);
+                    return;
+                }
 
-            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
-            var settings = UserSettings.Load(encryptedStore);
+                var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
+                var settings = UserSettings.Load(encryptedStore);
 
-            if (string.IsNullOrEmpty(settings.DefaultJournalRoot))
-                throw new PSInvalidOperationException(Error);
+                if (string.IsNullOrEmpty(settings.DefaultJournalRoot))
+                    throw new PSInvalidOperationException(Error);
 
                 Location = settings.DefaultJournalRoot;
 

--- a/src/JournalCli/Cmdlets/NewCompiledJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/NewCompiledJournalEntryCmdlet.cs
@@ -28,9 +28,8 @@ namespace JournalCli.Cmdlets
 
         public SwitchParameter Force { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
             var journal = OpenJournal();
 
             switch (ParameterSetName)

--- a/src/JournalCli/Cmdlets/NewJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/NewJournalEntryCmdlet.cs
@@ -23,10 +23,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public DateTime? Date { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             var journal = OpenJournal();
             var entryDate = Date == null ? Today.PlusDays(DateOffset) : LocalDate.FromDateTime(Date.Value).PlusDays(DateOffset);
 

--- a/src/JournalCli/Cmdlets/OpenJournalCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalCmdlet.cs
@@ -21,10 +21,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public DateTime Date { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-            
             var fileSystem = new FileSystem();
             string path;
             var year = Journal.YearDirectoryPattern.Format(Today.Date());

--- a/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
@@ -29,10 +29,8 @@ namespace JournalCli.Cmdlets
         [Parameter(Position = 0, ParameterSetName = "DateOffset")]
         public int DateOffset { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             if (Last)
             {
                 var journal = OpenJournal();

--- a/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
@@ -33,7 +33,7 @@ namespace JournalCli.Cmdlets
         {
             base.ProcessRecord();
 
-            if (ParameterSetName == "Last")
+            if (Last)
             {
                 var journal = OpenJournal();
                 var lastEntry = journal.CreateIndex<JournalEntryFile>().SelectMany(x => x.Entries).OrderByDescending(x => x.EntryDate).First();

--- a/src/JournalCli/Cmdlets/OpenRandomJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenRandomJournalEntryCmdlet.cs
@@ -23,10 +23,8 @@ namespace JournalCli.Cmdlets
         [Parameter]
         public string[] Tags { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             var range = ParameterSetName == "Year" ? new DateRange(new LocalDate(Year, 1, 1), new LocalDate(Year, 12, 31)) : GetRangeOrNull(From, To);
             var journal = OpenJournal();
 

--- a/src/JournalCli/Cmdlets/RenameJournalTagCmdlet.cs
+++ b/src/JournalCli/Cmdlets/RenameJournalTagCmdlet.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using JetBrains.Annotations;
-using JournalCli.Core;
 using JournalCli.Infrastructure;
 
 namespace JournalCli.Cmdlets
@@ -22,10 +19,8 @@ namespace JournalCli.Cmdlets
         [Parameter(Mandatory = true)]
         public string NewName { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
             if (!DryRun && !YesOrNo($"Are you sure you want to rename all '{OldName}' tags to '{NewName}'?"))
                 return;
 

--- a/src/JournalCli/Cmdlets/SaveJournalSnapshotCmdlet.cs
+++ b/src/JournalCli/Cmdlets/SaveJournalSnapshotCmdlet.cs
@@ -13,14 +13,12 @@ namespace JournalCli.Cmdlets
         [ValidateLength(5, 60)]
         public string Message { get; set; }
 
-        protected override void ProcessRecord()
+        protected override void RunJournalCommand()
         {
-            base.ProcessRecord();
-
-            if (!string.IsNullOrEmpty(Message))
-                Commit(Message);
-            else
+            if (string.IsNullOrEmpty(Message))
                 Commit(GitCommitType.Manual);
+            else
+                Commit(Message);
         }
     }
 }

--- a/src/JournalCli/Cmdlets/SuspendJournalCliUpdateChecksCmdlet.cs
+++ b/src/JournalCli/Cmdlets/SuspendJournalCliUpdateChecksCmdlet.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Management.Automation;
+using JetBrains.Annotations;
+using JournalCli.Core;
+using JournalCli.Infrastructure;
+
+namespace JournalCli.Cmdlets
+{
+    [PublicAPI]
+    [Cmdlet(VerbsLifecycle.Suspend, "JournalCliUpdateChecks")]
+    public class SuspendJournalCliUpdateChecksCmdlet : CmdletBase
+    {
+        [Parameter] 
+        [ValidateRange(1, 365)]
+        public int Days { get; set; } = 45;
+
+        protected override void ProcessRecord()
+        {
+            var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
+            var settings = UserSettings.Load(encryptedStore);
+            settings.NextUpdateCheck = DateTime.Now.AddDays(Days);
+            settings.Save(encryptedStore);
+        }
+    }
+}

--- a/src/JournalCli/Core/UserSettings.cs
+++ b/src/JournalCli/Core/UserSettings.cs
@@ -15,6 +15,8 @@ namespace JournalCli.Core
 
         public string BackupPassword { get; set; }
 
+        public DateTime? NextUpdateCheck { get; set; }
+
         public void Save(IEncryptedStore<UserSettings> encryptedStore) => encryptedStore.Save(this);
 
         public bool Equals(UserSettings other)

--- a/src/JournalCli/Infrastructure/Extensions.cs
+++ b/src/JournalCli/Infrastructure/Extensions.cs
@@ -56,5 +56,7 @@ namespace JournalCli.Infrastructure
                     throw new ArgumentOutOfRangeException(nameof(dayOfWeek), dayOfWeek, null);
             }
         }
+
+        public static bool IsBeta(this Version version) => version.Major == 0 && version.Minor == 0;
     }
 }

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -33,8 +33,11 @@
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="NodaTime" Version="2.4.7" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.IO.Abstractions" Version="7.0.4" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- **Automatic Update Checks**: Once every 7 days, `journal-cli` will automatically check for newly released updates. If one is found, a message will be relayed to the user about the new version that is available and how to install it. 
- **Logging**: All unhandled errors and some handled errors are now logged to local files, which might be useful for troubleshooting and/or debugging problems. 

## Issues closed or fixed
- Closes #31 
- Closes #33 

## Required tasks
- [x] Update Docs
