### PR TITLE
Fix Open-RandomEntry so no parameters are mandatory

### DIFF
--- a/src/JournalCli/Cmdlets/OpenRandomJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenRandomJournalEntryCmdlet.cs
@@ -11,10 +11,10 @@ namespace JournalCli.Cmdlets
     [Alias("orj")]
     public class OpenRandomJournalEntryCmdlet : JournalCmdletBase
     {
-        [Parameter]
+        [Parameter(ParameterSetName = "Range")]
         public DateTime? From { get; set; }
 
-        [Parameter]
+        [Parameter(ParameterSetName = "Range")]
         public DateTime To { get; set; } = DateTime.Now;
 
         [Parameter(ParameterSetName = "Year", Mandatory = true)]


### PR DESCRIPTION
## Summary
This change allows `Open-RandomJournalEntry` to be run without any parameters, which is the intended behavior. 