### PR TITLE
Bug Fix: Manually specifying a -Location parameter not working

### DIFF
--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -29,19 +29,20 @@ namespace JournalCli.Cmdlets
         {
             try
             {
-                if (!string.IsNullOrEmpty(Location))
+                if (string.IsNullOrEmpty(Location))
+                {
+                    var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
+                    var settings = UserSettings.Load(encryptedStore);
+
+                    if (string.IsNullOrEmpty(settings.DefaultJournalRoot))
+                        throw new PSInvalidOperationException(Error);
+
+                    Location = settings.DefaultJournalRoot;
+                }
+                else
                 {
                     Location = ResolvePath(Location);
-                    return;
                 }
-
-                var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
-                var settings = UserSettings.Load(encryptedStore);
-
-                if (string.IsNullOrEmpty(settings.DefaultJournalRoot))
-                    throw new PSInvalidOperationException(Error);
-
-                Location = settings.DefaultJournalRoot;
 
                 RunJournalCommand();
             }

--- a/src/JournalCli/Infrastructure/MacEncryptedStore.cs
+++ b/src/JournalCli/Infrastructure/MacEncryptedStore.cs
@@ -52,7 +52,7 @@ namespace JournalCli.Infrastructure
                 var cipherPath = _fileSystem.Path.Combine(StorageLocation, typeof(T).Name);
                 var cipherText = _fileSystem.File.ReadAllText(cipherPath);
                 var plainText = AuthenticatedEncryption.Decrypt(cipherText, cryptKey, authKey);
-                var deserializer = new DeserializerBuilder().Build();
+                var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
                 return deserializer.Deserialize<T>(plainText);
             }
             catch (Exception)

--- a/src/JournalCli/Infrastructure/WindowsEncryptedStore.cs
+++ b/src/JournalCli/Infrastructure/WindowsEncryptedStore.cs
@@ -51,7 +51,7 @@ namespace JournalCli.Infrastructure
                 var resultBytes = ProtectedData.Unprotect(cipher, entropy, DataProtectionScope.CurrentUser);
                 var yaml = Encoding.UTF8.GetString(resultBytes);
 
-                var deserializer = new DeserializerBuilder().Build();
+                var deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
                 return deserializer.Deserialize<T>(yaml);
             }
             catch (Exception)


### PR DESCRIPTION
## Summary
The code as currently written will skip core `ProcessRecord()` functionality if the `-Location` parameter is specified. Basically, manually specifying the `-Location` parameter is causing the cmdlet itself not to run. 
