### PR TITLE
Return PS-friendly file objects, improve update checks, added error handling, default tags

### DIFF
--- a/src/JournalCli.Tests/JournalFrontMatterTests.cs
+++ b/src/JournalCli.Tests/JournalFrontMatterTests.cs
@@ -13,6 +13,14 @@ namespace JournalCli.Tests
     public class JournalFrontMatterTests
     {
         [Fact]
+        public void AppendTags_AddsTags_WhenNoCurrentTagsExist()
+        {
+            var frontMatter = new JournalFrontMatter(string.Empty, null);
+            frontMatter.AppendTags(new[] { "test" });
+            frontMatter.Tags.Should().Contain("test");
+        }
+
+        [Fact]
         public void ToString_ShouldInsertDefaultTags_IfNoneArePresent()
         {
             var frontMatter = new JournalFrontMatter(string.Empty, Today.Date());

--- a/src/JournalCli.Tests/JournalFrontMatterTests.cs
+++ b/src/JournalCli.Tests/JournalFrontMatterTests.cs
@@ -12,6 +12,17 @@ namespace JournalCli.Tests
 {
     public class JournalFrontMatterTests
     {
+        [Fact]
+        public void ToString_ShouldInsertDefaultTags_IfNoneArePresent()
+        {
+            var frontMatter = new JournalFrontMatter(string.Empty, Today.Date());
+            var yaml = frontMatter.ToString(true);
+            yaml.Should().Contain("- (untagged)");
+
+            var text = frontMatter.ToString();
+            text.Should().Contain("- (untagged)");
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/src/JournalCli.Tests/JournalTests.cs
+++ b/src/JournalCli.Tests/JournalTests.cs
@@ -45,7 +45,7 @@ namespace JournalCli.Tests
             var journal = Journal.Open(ioFactory, markdownFiles, systemProcess);
             journal.CreateNewEntry(new LocalDate(2019, 7, 19), tags, readme);
 
-            fileSystem.GetFile("J:\\Current\\2019\\07 July\\2019.07.19.md").TextContents.Should().Be("---\r\n\r\n---\r\n# Friday, July 19, 2019\r\n");
+            fileSystem.GetFile("J:\\Current\\2019\\07 July\\2019.07.19.md").TextContents.Should().Be("---\r\ntags:\r\n  - (untagged)\r\n---\r\n# Friday, July 19, 2019\r\n");
         }
 
         [Fact]

--- a/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
@@ -30,7 +29,7 @@ namespace JournalCli.Cmdlets
             {
                 var fileSystem = new FileSystem();
                 var markdownFiles = new MarkdownFiles(fileSystem, Location);
-                var results = markdownFiles.FindAll().Select(x => new FileInfo(x));
+                var results = markdownFiles.FindAll().Select(x => new JournalFileInfo(x));
                 WriteObject(results, true);
 
                 return;
@@ -38,7 +37,7 @@ namespace JournalCli.Cmdlets
 
             var journal = OpenJournal();
             var index = journal.CreateIndex<JournalEntryFile>(dateRange, Tags);
-            var entries = index.SelectMany(x => x.Entries).Distinct().Select(x => new FileInfo(x.FilePath));
+            var entries = index.SelectMany(x => x.Entries).Distinct().Select(x => new JournalFileInfo(x.FilePath));
             WriteObject(entries, true);
         }
     }

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -174,7 +174,14 @@ namespace JournalCli.Cmdlets
             ProgressRecord progressRecord = null;
             try
             {
-                if (_settings.NextUpdateCheck != null && DateTime.Now <= _settings.NextUpdateCheck)
+                if (_settings.NextUpdateCheck == null)
+                {
+                    _settings.NextUpdateCheck = DateTime.Now.AddDays(7);
+                    _settings.Save(_encryptedStore);
+                    return;
+                }
+
+                if (DateTime.Now <= _settings.NextUpdateCheck)
                     return;
 
                 progressRecord = new ProgressRecord(0, "Checking For Updates", "This won't take long...");

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -55,6 +55,10 @@ namespace JournalCli.Cmdlets
             }
             catch (Exception e)
             {
+                if (e is PipelineStoppedException ||
+                    e is PipelineClosedException)
+                    throw;
+
                 Log.Error(e, "Error encountered during ProcessRecord");
                 throw;
             }

--- a/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
@@ -34,7 +34,9 @@ namespace JournalCli.Cmdlets
             if (Last)
             {
                 var journal = OpenJournal();
-                var lastEntry = journal.CreateIndex<JournalEntryFile>().SelectMany(x => x.Entries).OrderByDescending(x => x.EntryDate).First();
+                var lastEntry = journal.CreateIndex<JournalEntryFile>().SelectMany(x => x.Entries).OrderByDescending(x => x.EntryDate).FirstOrDefault();
+                if (lastEntry == null)
+                    throw new PSInvalidOperationException("No entries found!");
                 SystemProcess.Start(lastEntry.FilePath);
                 return;
             }

--- a/src/JournalCli/Core/JournalFrontMatter.cs
+++ b/src/JournalCli/Core/JournalFrontMatter.cs
@@ -108,7 +108,7 @@ namespace JournalCli.Core
                     if (node.NodeType == YamlNodeType.Sequence)
                     {
                         var tags = (YamlSequenceNode)node;
-                        Tags = tags.Select(x => x.ToString()).Distinct().OrderBy(x => x).ToList();
+                        Tags = tags.Select(x => x.ToString()).Where(x => x != "(untagged)").Distinct().OrderBy(x => x).ToList();
                     }
                 }
 
@@ -147,11 +147,9 @@ namespace JournalCli.Core
 
         public string ToString(bool asFrontMatter)
         {
-            if (IsEmpty())
-                return asFrontMatter ? $"{BlockIndicator}{Environment.NewLine}{Environment.NewLine}{BlockIndicator}{Environment.NewLine}" : "";
-
+            var target = IsEmpty() ? new JournalFrontMatter(new[] { "(untagged)" }) : this;
             var serializer = new SerializerBuilder().Build();
-            var yaml = serializer.Serialize(this).Replace("- ", "  - ").Trim();
+            var yaml = serializer.Serialize(target).Replace("- ", "  - ").Trim();
             return asFrontMatter ? $"{BlockIndicator}{Environment.NewLine}{yaml}{Environment.NewLine}{BlockIndicator}{Environment.NewLine}" : yaml;
         }
 

--- a/src/JournalCli/Core/JournalFrontMatter.cs
+++ b/src/JournalCli/Core/JournalFrontMatter.cs
@@ -66,6 +66,13 @@ namespace JournalCli.Core
 
         public JournalFrontMatter(string yamlFrontMatter, LocalDate? journalEntryDate)
         {
+            if (string.IsNullOrWhiteSpace(yamlFrontMatter))
+                return;
+
+            var skipChars = Environment.NewLine.ToCharArray().Concat(new[] { '-' });
+            if (yamlFrontMatter.All(x => skipChars.Contains(x)))
+                return;
+
             yamlFrontMatter = yamlFrontMatter.Trim();
             var yamlLines = yamlFrontMatter.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).ToList();
             var originalLineCount = yamlLines.Count;

--- a/src/JournalCli/Core/JournalFrontMatter.cs
+++ b/src/JournalCli/Core/JournalFrontMatter.cs
@@ -142,7 +142,10 @@ namespace JournalCli.Core
             if (tags == null || !tags.Any())
                 return;
 
-            Tags = Tags.Concat(tags).Distinct().OrderBy(x => x).ToList().AsReadOnly();
+            if (Tags == null)
+                Tags = tags.ToList();
+            else 
+                Tags = Tags.Concat(tags).Distinct().OrderBy(x => x).ToList().AsReadOnly();
         }
 
         public string ToString(bool asFrontMatter)

--- a/src/JournalCli/Infrastructure/JournalFileInfo.cs
+++ b/src/JournalCli/Infrastructure/JournalFileInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Management.Automation;
+
+namespace JournalCli.Infrastructure
+{
+    public class JournalFileInfo
+    {
+        public JournalFileInfo(FileInfo fileInfo)
+        {
+            File = fileInfo;
+            Path = fileInfo.FullName;
+        }
+
+        public JournalFileInfo(string filePath)
+        {
+            File = new FileInfo(filePath);
+            Path = filePath;
+        }
+
+        public string Path { get; }
+
+        [Hidden]
+        public FileInfo File { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- `Get-JournalFiles` now returns a `JournalFileInfo` object instead of a `FileInfo` object. The former has a `Path` property, which allows it to play nice with PS cmdlets such as `Get-Content`. The underlying `FileInfo` object is still accessible by the hidden `File` property. (Hidden to avoid displaying redundant information when printing the results of  `Get-JournalFiles` to the screen.
- Update checks will not be performed until 7 days _after_ the initial installation.
- `FrontMatter` objects can now be created with empty yaml strings.
- Journal entries created without tags will have a default tag inserted of `(untagged)`. This is because entries without any tags are effectively orphaned; most journal functions can't "see" them. Adding any non-default tags will cause `(untagged)` to be removed.

## Issues closed or fixed
- Fixes #46 
- Fixes #44 
- Closes #43 
