### PR TITLE
Sorting & limiting when retrieving journal files; iterative blocking when reading/editing; updated cmdlet names

### DIFF
--- a/debug.ps1
+++ b/debug.ps1
@@ -1,10 +1,11 @@
 param(
-    [Parameter(Position = 0, Mandatory = $true)][string]$ProjectName
+    [Parameter(Position = 0, Mandatory = $true)][string]$ProjectName,
+    [Parameter(Position = 1)]$Configuration = "Debug"
 )
 
 $ErrorActionPreference = 'Stop'
 
 Remove-Item "$PSScriptRoot\publish\$ProjectName\" -Recurse -Force -ErrorAction SilentlyContinue
 $proj = Get-ChildItem -Filter "$ProjectName.csproj" -Recurse | Select-Object -First 1 -ExpandProperty FullName
-dotnet publish $proj -r 'win10-x64' --output "$PSScriptRoot\publish\$ProjectName" --self-contained true
+dotnet publish $proj -r 'win10-x64' --output "$PSScriptRoot\publish\$ProjectName" --self-contained true -c $Configuration
 Import-Module "$PSScriptRoot\publish\$ProjectName\$ProjectName.dll"

--- a/src/JournalCli.Tests/JournalFrontMatterTests.cs
+++ b/src/JournalCli.Tests/JournalFrontMatterTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Abstractions;
+﻿using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 using FluentAssertions;
 using JournalCli.Core;

--- a/src/JournalCli.Tests/JournalReaderTests.cs
+++ b/src/JournalCli.Tests/JournalReaderTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 using FluentAssertions;

--- a/src/JournalCli.Tests/TestEntries.cs
+++ b/src/JournalCli.Tests/TestEntries.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace JournalCli.Tests
+﻿namespace JournalCli.Tests
 {
     public static class TestEntries
     {

--- a/src/JournalCli.Tests/TodayTests.cs
+++ b/src/JournalCli.Tests/TodayTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using AutoFixture;
 using FluentAssertions;
 using JournalCli.Infrastructure;
 using NodaTime;

--- a/src/JournalCli/Cmdlets/AddJournalEntryContentCmdlet.cs
+++ b/src/JournalCli/Cmdlets/AddJournalEntryContentCmdlet.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Management.Automation;
-using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using JournalCli.Infrastructure;
 using NodaTime;

--- a/src/JournalCli/Cmdlets/GetJournalDefaultLocationCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalDefaultLocationCmdlet.cs
@@ -6,12 +6,16 @@ using JournalCli.Infrastructure;
 namespace JournalCli.Cmdlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "DefaultJournalLocation")]
+    [Cmdlet(VerbsCommon.Get, "JournalDefaultLocation")]
     [OutputType(typeof(string))]
-    public class GetDefaultJournalLocationCmdlet : CmdletBase
+    [Alias("Get-DefaultJournalLocation")]
+    public class GetJournalDefaultLocationCmdlet : CmdletBase
     {
         protected override void ProcessRecord()
         {
+            if (MyInvocation.InvocationName == "Get-DefaultJournalLocation")
+                WriteWarning("'Get-DefaultJournalLocation' is obsolete and will be removed in a future release. Use 'Get-JournalDefaultLocation' instead.");
+
             var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
             WriteObject(settings.DefaultJournalRoot);

--- a/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalFilesCmdlet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;

--- a/src/JournalCli/Cmdlets/GetJournalReadmeEntriesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetJournalReadmeEntriesCmdlet.cs
@@ -7,9 +7,10 @@ using JournalCli.Infrastructure;
 namespace JournalCli.Cmdlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Get, "ReadmeEntries", DefaultParameterSetName = "All")]
+    [Cmdlet(VerbsCommon.Get, "JournalReadmeEntries", DefaultParameterSetName = "All")]
     [OutputType(typeof(ReadmeJournalEntryCollection))]
-    public class GetReadmeEntriesCmdlet : JournalCmdletBase
+    [Alias("Get-ReadmeEntries")]
+    public class GetJournalReadmeEntriesCmdlet : JournalCmdletBase
     {
         [Parameter(DontShow = true)]
         public SwitchParameter IncludeFuture { get; set; }
@@ -26,6 +27,9 @@ namespace JournalCli.Cmdlets
 
         protected override void RunJournalCommand()
         {
+            if (MyInvocation.InvocationName == "Get-ReadmeEntries")
+                WriteWarning("'Get-ReadmeEntries' is obsolete and will be removed in a future release. Use 'Get-JournalReadmeEntries' instead.");
+
             if (ParameterSetName == "Range")
             {
                 if (Duration == 0)

--- a/src/JournalCli/Cmdlets/GetRecentJournalEntriesCmdlet.cs
+++ b/src/JournalCli/Cmdlets/GetRecentJournalEntriesCmdlet.cs
@@ -1,4 +1,5 @@
-﻿using System.IO.Abstractions;
+﻿using System;
+using System.IO.Abstractions;
 using System.Management.Automation;
 using JetBrains.Annotations;
 using JournalCli.Core;
@@ -8,6 +9,7 @@ namespace JournalCli.Cmdlets
 {
     [PublicAPI]
     [Cmdlet(VerbsCommon.Get, "RecentJournalEntries")]
+    [Obsolete("It will be removed in a future release. Use Get-JournalFiles instead.")]
     public class GetRecentJournalEntriesCmdlet : JournalCmdletBase
     {
         [Parameter]

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.ObjectModel;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
-using System.Threading;
-using System.Threading.Tasks;
 using JournalCli.Core;
 using JournalCli.Infrastructure;
 using Serilog;

--- a/src/JournalCli/Cmdlets/OpenJournalBackupLocationCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalBackupLocationCmdlet.cs
@@ -7,11 +7,15 @@ using JournalCli.Infrastructure;
 namespace JournalCli.Cmdlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Open, "BackupLocation")]
-    public class OpenBackupLocationCmdlet : CmdletBase
+    [Cmdlet(VerbsCommon.Open, "JournalBackupLocation")]
+    [Alias("Open-BackupLocation")]
+    public class OpenJournalBackupLocationCmdlet : CmdletBase
     {
         protected override void ProcessRecord()
         {
+            if (MyInvocation.InvocationName == "Open-BackupLocation")
+                WriteWarning("'Open-BackupLocation' is obsolete and will be removed in a future release. Use 'Open-JournalBackupLocation' instead.");
+
             var fileSystem = new FileSystem();
             var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var path = UserSettings.Load(encryptedStore).BackupLocation;

--- a/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
@@ -82,11 +82,13 @@ namespace JournalCli.Cmdlets
             if (!fileSystem.File.Exists(path))
                 throw new PSInvalidOperationException($"An entry does not exist for '{entryDate}'.");
 
+            Commit(GitCommitType.PreOpenJournalEntry);
             SystemProcess.Start(path);
 
             if (Wait)
             {
                 var result = Choice($"Reading entry for {entryDate}", "Continue on to next entry?", 0, "&Continue", "&Quit");
+                Commit(GitCommitType.PostOpenJournalEntry);
                 if (result == 1)
                     ThrowTerminatingError("Pipeline terminated at user's request.", ErrorCategory.NotSpecified);
             }

--- a/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
+++ b/src/JournalCli/Cmdlets/OpenJournalEntryCmdlet.cs
@@ -29,6 +29,9 @@ namespace JournalCli.Cmdlets
         [Parameter(Position = 0, ParameterSetName = "DateOffset")]
         public int DateOffset { get; set; }
 
+        [Parameter(ParameterSetName = "Entry")]
+        public SwitchParameter Wait { get; set; }
+
         protected override void RunJournalCommand()
         {
             if (Last)
@@ -80,6 +83,13 @@ namespace JournalCli.Cmdlets
                 throw new PSInvalidOperationException($"An entry does not exist for '{entryDate}'.");
 
             SystemProcess.Start(path);
+
+            if (Wait)
+            {
+                var result = Choice($"Reading entry for {entryDate}", "Continue on to next entry?", 0, "&Continue", "&Quit");
+                if (result == 1)
+                    ThrowTerminatingError("Pipeline terminated at user's request.", ErrorCategory.NotSpecified);
+            }
         }
     }
 }

--- a/src/JournalCli/Cmdlets/SetJournalDefaultLocationCmdlet.cs
+++ b/src/JournalCli/Cmdlets/SetJournalDefaultLocationCmdlet.cs
@@ -6,14 +6,18 @@ using JournalCli.Infrastructure;
 namespace JournalCli.Cmdlets
 {
     [PublicAPI]
-    [Cmdlet(VerbsCommon.Set, "DefaultJournalLocation")]
-    public class SetDefaultJournalLocationCmdlet : CmdletBase
+    [Cmdlet(VerbsCommon.Set, "JournalDefaultLocation")]
+    [Alias("Set-DefaultJournalLocation")]
+    public class SetJournalDefaultLocationCmdlet : CmdletBase
     {
         [Parameter(Mandatory = true, Position = 0)]
         public string Location { get; set; }
 
         protected override void ProcessRecord()
         {
+            if (MyInvocation.InvocationName == "Set-DefaultJournalLocation")
+                WriteWarning("'Set-DefaultJournalLocation' is obsolete and will be removed in a future release. Use 'Set-JournalDefaultLocation' instead.");
+
             var encryptedStore = EncryptedStoreFactory.Create<UserSettings>();
             var settings = UserSettings.Load(encryptedStore);
             settings.DefaultJournalRoot = Location;

--- a/src/JournalCli/Infrastructure/GitCommitMessage.cs
+++ b/src/JournalCli/Infrastructure/GitCommitMessage.cs
@@ -10,25 +10,40 @@ namespace JournalCli.Infrastructure
             {
                 default:
                     throw new NotSupportedException($"The commit type '{commitType}' is not currently supported");
+                case GitCommitType.PreOpenJournalEntry:
+                    return Pre + OpenForEdit;
+
+                case GitCommitType.PostOpenJournalEntry:
+                    return Post + OpenForEdit;
+
                 case GitCommitType.PreAppendJournalEntry:
-                    return "PRE: " + AppendJournalEntry;
+                    return Pre + AppendJournalEntry;
+
                 case GitCommitType.PostAppendJournalEntry:
-                    return "POST: " + AppendJournalEntry;
+                    return Post + AppendJournalEntry;
+
                 case GitCommitType.PreNewJournalEntry:
-                    return "PRE: " + NewJournalEntry;
+                    return Pre + NewJournalEntry;
+
                 case GitCommitType.PostNewJournalEntry:
-                    return "POST: " + NewJournalEntry;
+                    return Post + NewJournalEntry;
+
                 case GitCommitType.PreRenameTag:
-                    return "PRE: " + RenameTag;
+                    return Pre + RenameTag;
+
                 case GitCommitType.PostRenameTag:
-                    return "POST: " + RenameTag;
+                    return Post + RenameTag;
+
                 case GitCommitType.Manual:
                     return "Manual snapshot";
             }
         }
 
+        private const string Pre = "PRE:  ";
+        private const string Post = "POST: ";
         private const string AppendJournalEntry = "Append content to journal entry";
         private const string NewJournalEntry = "Add new journal entry";
         private const string RenameTag = "Rename tag";
+        private const string OpenForEdit = "Open entry for editing";
     }
 }

--- a/src/JournalCli/Infrastructure/GitCommitType.cs
+++ b/src/JournalCli/Infrastructure/GitCommitType.cs
@@ -8,6 +8,8 @@
         PostAppendJournalEntry,
         PreRenameTag,
         PostRenameTag,
-        Manual
+        Manual,
+        PreOpenJournalEntry,
+        PostOpenJournalEntry
     }
 }


### PR DESCRIPTION
## Summary
- Marked `Get-RecentJournalEntries` as obsolete and moved the functionality to `Get-JournalEntryFiles` cmdlet. 
- `Get-JournalEntryFiles` can now sort entries by date.
- Added `-Wait` switch parameter to `Open-JournalEntry` cmdlet when piping `IJournalEntry` objects in. This allows reading/editing entries one at at time.
- Updated several cmdlets so they match the naming convention of `Verb-JournalNoun`. I did not apply this to cmdlets where the result would have sounded silly or nonsensical. 
