### PR TITLE
Add additional logging for missing native binary errors

### DIFF
--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -16,7 +16,7 @@ namespace JournalCli.Cmdlets
         private readonly IEncryptedStore<UserSettings> _encryptedStore;
 
 #if !DEBUG
-        private bool _beenWarned;
+        private static bool _beenWarned;
         private const string MissingGitBinaryWarning = "You're missing a native binary that's required to enable git integration. " +
             "Click here for more information:\r\n\r\nhttps://journalcli.me/docs/faq#i-got-a-missing-git-binary-warning-whats-that-about\r\n";
 #endif

--- a/src/JournalCli/Cmdlets/JournalCmdletBase.cs
+++ b/src/JournalCli/Cmdlets/JournalCmdletBase.cs
@@ -96,6 +96,7 @@ namespace JournalCli.Cmdlets
             }
             catch (TypeInitializationException e) when (e.InnerException is DllNotFoundException)
             {
+                Log.Error(e, "Error encountered during Commit()");
                 if (!_beenWarned)
                 {
                     WriteWarning(MissingGitBinaryWarning);
@@ -115,6 +116,7 @@ namespace JournalCli.Cmdlets
             }
             catch (TypeInitializationException e) when (e.InnerException is DllNotFoundException)
             {
+                Log.Error(e, "Error encountered during Commit()");
                 if (!_beenWarned)
                 {
                     WriteWarning(MissingGitBinaryWarning);


### PR DESCRIPTION
## Summary
Two things here. First, I made the `_beenWarned` bool static, so users are only warned about missing native binaries once per session. (This should have been the behavior all along.) Second, I added additional logging so I can capture the exact error message generated with the binary doesn't load correctly. This is partly in response to #60, where the binary clearly isn't loading correctly even though it is present on the system. Hopefully additional logging will help me find a resolution. 