### PR TITLE
Ubuntu 20

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ if ($LASTEXITCODE -ne 0) {
   throw "Failed to publish application."
 }
 
-$targets = 'win-x64','linux-x64','osx-x64','ubuntu.18.04-x64'
+$targets = 'win-x64','linux-x64','osx-x64'
 foreach ($target in $targets) {
   dotnet publish $proj -c Release --self-contained true -r $target --output "$publishOutputDir\$target"
   if ($LASTEXITCODE -ne 0) {

--- a/src/JournalCli/JournalCli.csproj
+++ b/src/JournalCli/JournalCli.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="AuthenticatedEncryption" Version="2.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0096" />
     <PackageReference Include="NodaTime" Version="3.0.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />


### PR DESCRIPTION
## Summary
According to [this](https://github.com/libgit2/libgit2sharp/issues/1747#issuecomment-743185544), the most recent version of LIbGit2Sharp no longer has the dependency that was causing #60 from the get-go. So I upgraded that package and modified the build and we'll see if that resolves the problem.
