### PR TITLE
Copy Ubuntu 18 binaries on exception

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ if ($LASTEXITCODE -ne 0) {
   throw "Failed to publish application."
 }
 
-$targets = 'win-x64','linux-x64','osx-x64'
+$targets = 'win-x64','linux-x64','osx-x64','ubuntu.18.04-x64'
 foreach ($target in $targets) {
   dotnet publish $proj -c Release --self-contained true -r $target --output "$publishOutputDir\$target"
   if ($LASTEXITCODE -ne 0) {

--- a/src/JournalCli/Cmdlets/CmdletBase.cs
+++ b/src/JournalCli/Cmdlets/CmdletBase.cs
@@ -13,7 +13,7 @@ namespace JournalCli.Cmdlets
     public abstract class CmdletBase : PSCmdlet
     {
         private readonly ISystemProcess _systemProcess = SystemProcessFactory.Create();
-        private readonly Lazy<string> _assemblyName = new Lazy<string>(() => Assembly.GetExecutingAssembly().FullName);
+        private readonly Lazy<string> _assemblyName = new(() => Assembly.GetExecutingAssembly().FullName);
 
         protected CmdletBase()
         {

--- a/src/JournalCli/Cmdlets/CmdletBase.cs
+++ b/src/JournalCli/Cmdlets/CmdletBase.cs
@@ -18,7 +18,8 @@ namespace JournalCli.Cmdlets
         protected CmdletBase()
         {
             // ReSharper disable AssignNullToNotNullAttribute
-            LogsDirectory = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "logs");
+            ModuleDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            LogsDirectory = Path.Combine(ModuleDirectory, "logs");
             var path = Path.Combine(LogsDirectory, ".log");
             // ReSharper restore AssignNullToNotNullAttribute
             Log.Logger = new LoggerConfiguration()
@@ -27,6 +28,8 @@ namespace JournalCli.Cmdlets
         }
 
         protected string LogsDirectory { get; }
+
+        protected string ModuleDirectory { get; }
 
         protected string ResolvePath(string path) => GetUnresolvedProviderPathFromPSPath(path);
 


### PR DESCRIPTION
## Summary
Yet another attempt at resolving #60. This time I'm simply moving/overwriting the linux LibGit2Sharp binaries with those built for Ubuntu 18. Been avoiding this solution for a while because it feels like a stupid hack, but at this point I just want the problem to go away.
